### PR TITLE
refactor: simplify delete_zip_folder function since zip.deleteFile now delete folders in the correct way

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -88,7 +88,7 @@
 		"@tailwindcss/line-clamp": "^0.4.4",
 		"@types/adm-zip": "^0.5.5",
 		"@types/prismjs": "^1.26.4",
-		"adm-zip": "^0.5.14",
+		"adm-zip": "^0.5.15",
 		"asn1js": "^3.0.5",
 		"buffer": "^6.0.3",
 		"classnames": "^2.5.1",

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^1.26.4
         version: 1.26.4
       adm-zip:
-        specifier: ^0.5.14
-        version: 0.5.14
+        specifier: ^0.5.15
+        version: 0.5.15
       asn1js:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1585,8 +1585,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.14:
-    resolution: {integrity: sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==}
+  adm-zip@0.5.15:
+    resolution: {integrity: sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==}
     engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
@@ -6254,7 +6254,7 @@ snapshots:
 
   acorn@8.12.1: {}
 
-  adm-zip@0.5.14: {}
+  adm-zip@0.5.15: {}
 
   agent-base@6.0.2:
     dependencies:

--- a/webapp/src/routes/api/download-microservices/shared-operations.ts
+++ b/webapp/src/routes/api/download-microservices/shared-operations.ts
@@ -42,7 +42,7 @@ export function get_folders_paths_to_delete(microservice_to_keep: MicroserviceFo
 	return pipe(
 		config.folder_names.microservices,
 		R.filter((folder_name) => folder_name != microservice_to_keep),
-		R.map((folder_name) => [folder_name, `${config.folder_names.public}/${folder_name}`]),
+		R.map((folder_name) => [`${folder_name}/`, `${config.folder_names.public}/${folder_name}/`]),
 		R.toEntries,
 		A.map((entry) => entry[1]),
 		A.flatten

--- a/webapp/src/routes/api/download-microservices/utils/zip.ts
+++ b/webapp/src/routes/api/download-microservices/utils/zip.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import AdmZip from 'adm-zip';
-import { Array as A, pipe } from 'effect';
+import { pipe } from 'effect';
 
 //
 
@@ -42,14 +42,7 @@ export function update_zip_json_entry(
 }
 
 export function delete_zip_folder(zip: AdmZip, folder_path: string) {
-	pipe(
-		zip.getEntries(),
-		A.filter((entry) => !entry.isDirectory),
-		A.map((entry) => entry.entryName),
-		A.filter((entry_name) => entry_name.startsWith(folder_path)),
-		A.forEach((entry_name) => zip.deleteFile(entry_name))
-	);
-	zip.deleteFile(folder_path+'/');
+	zip.deleteFile(folder_path);
 }
 
 export function addZipAsSubfolder(


### PR DESCRIPTION
- chore: bump adm-zip to 0.5.15
- refactor: simplify delete_zip_folder function since zip.deleteFile now delete folders in the correct way
