### PR TITLE
fix: Didroom to DIDroom in Welcome page

### DIFF
--- a/webapp/src/app.html
+++ b/webapp/src/app.html
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
-		<title>Didroom</title>
+		<title>DIDroom</title>
 		%sveltekit.head%
 	</head>
 

--- a/webapp/src/lib/strings.ts
+++ b/webapp/src/lib/strings.ts
@@ -2,4 +2,4 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export const appTitle = 'Didroom';
+export const appTitle = 'DIDroom';


### PR DESCRIPTION
Trying to fix the string "Didroom" to "DIDroom" in Welcome page - that's the only occurrence I found 