### PR TITLE
fix(microservices): add bind mount for microservices config in compose template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: dyne/pnpm@main
         with:
           working-directory: webapp
+          node-version: 20.14.0
       - run: make build
       - run: pnpm i18n:lint
         working-directory: webapp
@@ -62,6 +63,7 @@ jobs:
       - uses: dyne/pnpm@main
         with:
           working-directory: ./webapp
+          node-version: 20.14.0
       - run: pnpm add -D @semantic-release/changelog @semantic-release/commit-analyzer @semantic-release/error @semantic-release/git @semantic-release/github @semantic-release/npm @semantic-release/release-notes-generator semantic-release 
       - run: pnpm semantic-release
         env:

--- a/webapp/src/routes/api/download-microservices/utils/dockercompose.ts
+++ b/webapp/src/routes/api/download-microservices/utils/dockercompose.ts
@@ -102,6 +102,9 @@ function dockerComposeTemplate(
     - type: bind
       source: ./${serviceFullName}/public
       target: /app/public
+    - type: bind
+      source: ~/.config/didroom
+      target: /root/.config/didroom
 `;
 }
 


### PR DESCRIPTION
Added a volume to bind `~/.config/didroom` to `/root/.config/didroom` in the `dockerComposeTemplate` function to ensure the microservices configuration is kept between deployments
